### PR TITLE
Update toBe.lua 

### DIFF
--- a/libs/jestronaut/expect/matchers/toBe.lua
+++ b/libs/jestronaut/expect/matchers/toBe.lua
@@ -17,6 +17,11 @@
 local function toBe(expect, expected)
     local actual = expect.actual
 
+    -- Special case: both actual and expected are nil
+    if actual == nil and expected == nil then
+        return true
+    end
+
     if not expect:checkEquals(actual, expected) then
         error("Expected " .. tostring(actual) .. (expect.inverse and " not " or "") .. " to be " .. tostring(expected))
     end


### PR DESCRIPTION
Fix: Allow :toBe(nil) to succeed when actual and expected are both nil

- Updated the toBe matcher to handle nil values properly.
- Added a special condition to check for both actual and expected being nil.
